### PR TITLE
This Pull Request introduces support for creating new secrets and updating existing secrets in the Akeyless GitHub Action.

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -73,6 +73,15 @@ inputs:
     description: "Value of the new secret to create"
     required: false
 
+
+  update-secret-name:
+    description: "Name of the existing secret to update"
+    required: false
+  update-secret-value:
+    description: "New value to update the secret with"
+    required: false
+
+
 outputs:
   token:
     description: 'Akeyless Token'

--- a/action.yml
+++ b/action.yml
@@ -65,6 +65,14 @@ inputs:
     default: false
     description: 'True/False to denote if environment variables should be created for each key/value pair in the JSON of the secret.'
 
+
+  create-secret-name:
+    description: "Name of the new secret to create"
+    required: false
+  create-secret-value:
+    description: "Value of the new secret to create"
+    required: false
+
 outputs:
   token:
     description: 'Akeyless Token'

--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,7 @@
 const core = require('@actions/core');
 const { akeylessLogin } = require('./auth')
 const input = require('./input');
-const { handleExportSecrets } = require('./secrets');
 const { handleExportSecrets, createSecret } = require('./secrets');
-const { createSecret } = require('./secrets'); 
-const { handleExportSecrets, handleCreateSecrets } = require('./secrets');
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,8 @@
 const core = require('@actions/core');
 const { akeylessLogin } = require('./auth')
 const input = require('./input');
-const { handleExportSecrets, createSecret } = require('./secrets');
+const { handleExportSecrets, handleCreateSecrets } = require('./secrets');
+
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,8 @@ const { akeylessLogin } = require('./auth')
 const input = require('./input');
 const { handleExportSecrets } = require('./secrets');
 const { handleExportSecrets, createSecret } = require('./secrets');
+const { createSecret } = require('./secrets'); 
+
 
 
 async function run() {
@@ -42,19 +44,23 @@ async function run() {
 
     core.debug(`Akeyless token length: ${akeylessToken.length}`);
 
+    // ✅ NEW: Read inputs for secret creation
     const createSecretName = core.getInput('create-secret-name');
     const createSecretValue = core.getInput('create-secret-value');
 
+    // ✅ NEW: Create secret if provided
     if (createSecretName && createSecretValue) {
         core.info(`Creating a new secret in Akeyless: ${createSecretName}`);
         try {
             await createSecret(akeylessToken, createSecretName, createSecretValue, apiUrl);
+            core.info(`✅ Secret created successfully`);
         } catch (error) {
-            core.setFailed(`Failed to create secret: ${error.message}`);
+            core.setFailed(`❌ Failed to create secret: ${typeof error === 'object' ? JSON.stringify(error) : error}`);
             return;
         }
     }
 
+    // ✅ Continue fetching secrets normally
     const args = {
         akeylessToken,
         staticSecrets,
@@ -73,16 +79,7 @@ async function run() {
     core.debug(`Done exporting secrets`);
 }
 
-if (require.main === module) {
-    try {
-        core.debug('Starting main run');
-        run();
-    } catch (error) {
-        core.debug(error.stack);
-        core.setFailed('Akeyless action has failed');
-        core.debug(error.message);
-    }
-}
+
 
 if (require.main === module) {
     try {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ const { handleExportSecrets, handleCreateSecrets } = require('./secrets');
 
 
 async function run() {
-    core.debug(`Getting Input for Akeyless github action`);
+    core.debug(`Getting Input for Akeyless GitHub Action`);
 
     const {
         accessId,
@@ -24,8 +24,8 @@ async function run() {
         parseJsonSecrets
     } = input.fetchAndValidateInput();
 
-    core.debug(`access id: ${accessId}`);
-    core.debug(`Fetch akeyless token with access type ${accessType}`);
+    core.debug(`Access ID: ${accessId}`);
+    core.debug(`Fetching Akeyless token with access type: ${accessType}`);
 
     let akeylessToken;
     try {
@@ -43,12 +43,11 @@ async function run() {
 
     core.debug(`Akeyless token length: ${akeylessToken.length}`);
 
-    // ✅ Prepare the list of secrets to create
+    // ✅ Prepare list of secrets to create
     const createSecretName = core.getInput('create-secret-name');
     const createSecretValue = core.getInput('create-secret-value');
 
     const secretsToCreate = [];
-
     if (createSecretName && createSecretValue) {
         secretsToCreate.push({
             name: createSecretName,
@@ -56,12 +55,35 @@ async function run() {
         });
     }
 
+    // ✅ Prepare list of secrets to update
+    const updateSecretName = core.getInput('update-secret-name');
+    const updateSecretValue = core.getInput('update-secret-value');
+
+    const secretsToUpdate = [];
+    if (updateSecretName && updateSecretValue) {
+        secretsToUpdate.push({
+            name: updateSecretName,
+            value: updateSecretValue,
+        });
+    }
+
     // ✅ Handle secret creation
-    await handleCreateSecrets({
-        akeylessToken,
-        secretsToCreate,
-        apiUrl,
-    });
+    if (secretsToCreate.length > 0) {
+        await handleCreateSecrets({
+            akeylessToken,
+            secretsToCreate,
+            apiUrl,
+        });
+    }
+
+    // ✅ Handle secret update
+    if (secretsToUpdate.length > 0) {
+        await handleUpdateSecrets({
+            akeylessToken,
+            secretsToUpdate,
+            apiUrl,
+        });
+    }
 
     // ✅ Then handle fetching secrets
     const args = {
@@ -79,8 +101,9 @@ async function run() {
 
     await handleExportSecrets(args);
 
-    core.debug(`Done exporting secrets`);
+    core.debug(`✅ Done processing all secrets`);
 }
+
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -43,7 +43,7 @@ async function run() {
 
     core.debug(`Akeyless token length: ${akeylessToken.length}`);
 
-    // ✅ Prepare list of secrets to create
+    // Prepare list of secrets to create
     const createSecretName = core.getInput('create-secret-name');
     const createSecretValue = core.getInput('create-secret-value');
 
@@ -55,7 +55,7 @@ async function run() {
         });
     }
 
-    // ✅ Prepare list of secrets to update
+    // Prepare list of secrets to update
     const updateSecretName = core.getInput('update-secret-name');
     const updateSecretValue = core.getInput('update-secret-value');
 
@@ -67,7 +67,7 @@ async function run() {
         });
     }
 
-    // ✅ Handle secret creation
+    // Handle secret creation
     if (secretsToCreate.length > 0) {
         await handleCreateSecrets({
             akeylessToken,
@@ -76,7 +76,7 @@ async function run() {
         });
     }
 
-    // ✅ Handle secret update
+    // Handle secret update
     if (secretsToUpdate.length > 0) {
         await handleUpdateSecrets({
             akeylessToken,
@@ -85,7 +85,7 @@ async function run() {
         });
     }
 
-    // ✅ Then handle fetching secrets
+    // Then handle fetching secrets
     const args = {
         akeylessToken,
         staticSecrets,
@@ -101,7 +101,7 @@ async function run() {
 
     await handleExportSecrets(args);
 
-    core.debug(`✅ Done processing all secrets`);
+    core.debug(`Done processing all secrets`);
 }
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -21,23 +21,17 @@ async function run() {
         token,
         exportSecretsToOutputs,
         exportSecretsToEnvironment,
-        parseJsonSecrets
+        parseJsonSecrets,
+        secretsToCreate,
+        secretsToUpdate
     } = input.fetchAndValidateInput();
-
-     // Prepare list of secrets to create
-     const createSecretName = core.getInput('create-secret-name');
-     const createSecretValue = core.getInput('create-secret-value');
-
-      // Prepare list of secrets to update
-    const updateSecretName = core.getInput('update-secret-name');
-    const updateSecretValue = core.getInput('update-secret-value');
 
     core.debug(`Access ID: ${accessId}`);
     core.debug(`Fetching Akeyless token with access type: ${accessType}`);
 
     let akeylessToken;
     try {
-        if (token !== "") {
+        if (token !== '') {
             akeylessToken = token;
         } else {
             const akeylessLoginResponse = await akeylessLogin(accessId, accessType, apiUrl);
@@ -49,23 +43,6 @@ async function run() {
         return;
     }
 
-    const secretsToCreate = [];
-    if (createSecretName && createSecretValue) {
-        secretsToCreate.push({
-            name: createSecretName,
-            value: createSecretValue,
-        });
-    }
-
-    const secretsToUpdate = [];
-    if (updateSecretName && updateSecretValue) {
-        secretsToUpdate.push({
-            name: updateSecretName,
-            value: updateSecretValue,
-        });
-    }
-
-    // Handle secret creation
     if (secretsToCreate.length > 0) {
         await handleCreateSecrets({
             akeylessToken,
@@ -74,7 +51,6 @@ async function run() {
         });
     }
 
-    // Handle secret update
     if (secretsToUpdate.length > 0) {
         await handleUpdateSecrets({
             akeylessToken,
@@ -83,7 +59,6 @@ async function run() {
         });
     }
 
-    // Then handle fetching secrets
     const args = {
         akeylessToken,
         staticSecrets,

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 const core = require('@actions/core');
 const { akeylessLogin } = require('./auth')
 const input = require('./input');
-const { handleExportSecrets, handleCreateSecrets } = require('./secrets');
+const { handleExportSecrets, handleCreateSecrets, handleUpdateSecrets } = require('./secrets');
 
 
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,14 @@ async function run() {
         parseJsonSecrets
     } = input.fetchAndValidateInput();
 
+     // Prepare list of secrets to create
+     const createSecretName = core.getInput('create-secret-name');
+     const createSecretValue = core.getInput('create-secret-value');
+
+      // Prepare list of secrets to update
+    const updateSecretName = core.getInput('update-secret-name');
+    const updateSecretValue = core.getInput('update-secret-value');
+
     core.debug(`Access ID: ${accessId}`);
     core.debug(`Fetching Akeyless token with access type: ${accessType}`);
 
@@ -41,12 +49,6 @@ async function run() {
         return;
     }
 
-    core.debug(`Akeyless token length: ${akeylessToken.length}`);
-
-    // Prepare list of secrets to create
-    const createSecretName = core.getInput('create-secret-name');
-    const createSecretValue = core.getInput('create-secret-value');
-
     const secretsToCreate = [];
     if (createSecretName && createSecretValue) {
         secretsToCreate.push({
@@ -54,10 +56,6 @@ async function run() {
             value: createSecretValue,
         });
     }
-
-    // Prepare list of secrets to update
-    const updateSecretName = core.getInput('update-secret-name');
-    const updateSecretValue = core.getInput('update-secret-value');
 
     const secretsToUpdate = [];
     if (updateSecretName && updateSecretValue) {
@@ -103,9 +101,6 @@ async function run() {
 
     core.debug(`Done processing all secrets`);
 }
-
-
-
 
 if (require.main === module) {
     try {

--- a/src/input.js
+++ b/src/input.js
@@ -13,13 +13,31 @@ const fetchAndValidateInput = () => {
         sshCertificate: parseAndValidateSecrets('ssh-certificates', ['name', 'cert-username', 'public-key-data'], ['output-name', 'key', 'prefix-json-secrets']),
         pkiCertificate: parseAndValidateSecrets('pki-certificates', ['name', 'csr-data-base64'], ['output-name', 'key', 'prefix-json-secrets']),
         token: core.getInput('token'),
-        exportSecretsToOutputs: core.getBooleanInput('export-secrets-to-outputs', {default: true}),
-        exportSecretsToEnvironment: core.getBooleanInput('export-secrets-to-environment', {default: true}),
-        parseJsonSecrets: core.getBooleanInput('parse-json-secrets', {default: false})
+        exportSecretsToOutputs: core.getBooleanInput('export-secrets-to-outputs', { default: true }),
+        exportSecretsToEnvironment: core.getBooleanInput('export-secrets-to-environment', { default: true }),
+        parseJsonSecrets: core.getBooleanInput('parse-json-secrets', { default: false }),
     };
-    if (params['token'] == "") {
-        validateRequiredParamsWhenTokenNotExist(params['accessId'], params['accessType'])
+
+    if (params.token === '') {
+        validateRequiredParamsWhenTokenNotExist(params.accessId, params.accessType);
     }
+
+    // Add create secret input
+    const createSecretName = core.getInput('create-secret-name');
+    const createSecretValue = core.getInput('create-secret-value');
+    params.secretsToCreate = [];
+    if (createSecretName && createSecretValue) {
+        params.secretsToCreate.push({ name: createSecretName, value: createSecretValue });
+    }
+
+    // Add update secret input
+    const updateSecretName = core.getInput('update-secret-name');
+    const updateSecretValue = core.getInput('update-secret-value');
+    params.secretsToUpdate = [];
+    if (updateSecretName && updateSecretValue) {
+        params.secretsToUpdate.push({ name: updateSecretName, value: updateSecretValue });
+    }
+
     return params;
 };
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -2,6 +2,7 @@ const core = require('@actions/core');
 const akeylessApi = require('./akeyless_api');
 const akeyless = require('akeyless');
 
+
 async function handleExportSecrets(args) {
     const {
         akeylessToken,
@@ -278,7 +279,7 @@ async function handleCreateSecrets(args) {
 
 
 exports.handleExportSecrets = handleExportSecrets
-exports.createSecret = createSecret
+exports.handleCreateSecrets = handleCreateSecrets;
 
 
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -277,6 +277,50 @@ async function handleCreateSecrets(args) {
 
 
 
+async function handleUpdateSecrets(args) {
+    const {
+        akeylessToken,
+        secretsToUpdate,
+        apiUrl,
+    } = args;
+
+    if (!secretsToUpdate || secretsToUpdate.length === 0) {
+        core.info('No secrets to update. Skipping secret update.');
+        return;
+    }
+
+    const api = akeylessApi.api(apiUrl);
+
+    for (const secret of secretsToUpdate) {
+        const { name, value } = secret;
+
+        if (!name || !value) {
+            core.warning(`Skipping secret update due to missing name or value: ${JSON.stringify(secret)}`);
+            continue;
+        }
+
+        const param = akeyless.UpdateSecretVal.constructFromObject({
+            token: akeylessToken,
+            name,
+            value,
+            format: "text",
+            accessibility: "regular",
+            json: false
+        });
+
+        try {
+            const result = await api.updateSecretVal(param);
+            core.info(`✅ Secret ${name} updated successfully`);
+        } catch (error) {
+            core.warning(`❌ Failed to update secret '${name}': ${typeof error === 'object' ? JSON.stringify(error) : error}`);
+        }
+    }
+}
+
+exports.handleUpdateSecrets = handleUpdateSecrets;
+
+
+
 
 exports.handleExportSecrets = handleExportSecrets
 exports.handleCreateSecrets = handleCreateSecrets;

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -237,24 +237,34 @@ function parseJson(jsonString) {
 async function createSecret(token, name, value, apiUrl) {
     const api = akeylessApi.api(apiUrl);
 
+    core.info(`🚀 About to call createSecret`);
+    core.info(`Token Length: ${token.length}`);
+    core.info(`Name: ${name}`);
+    core.info(`Value: ${value}`);
+
     const param = akeyless.CreateSecret.constructFromObject({
         token,
         name,
         value,
-        type: "generic",       // Text secret (can change to 'static' etc)
+        type: "generic",
         format: "text",
         accessibility: "regular",
     });
 
+    core.info(`CreateSecret Param: ${JSON.stringify(param)}`);
+
     try {
         const result = await api.createSecret(param);
-        core.info(`✅ Secret ${name} created successfully`);
+        core.info(`✅ CreateSecret API call succeeded`);
+        core.info(`API Response: ${JSON.stringify(result)}`);
         return result;
     } catch (error) {
-        core.setFailed(`❌ Failed to create secret: ${typeof error === 'object' ? JSON.stringify(error) : error}`);
+        core.error(`❌ API call to createSecret FAILED`);
+        core.error(`Error: ${typeof error === 'object' ? JSON.stringify(error) : error}`);
         throw error;
     }
 }
+
 
 
 exports.handleExportSecrets = handleExportSecrets

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -233,7 +233,34 @@ function parseJson(jsonString) {
     }
 }
 
+
+async function createSecret(token, name, value, apiUrl) {
+    const api = akeylessApi.api(apiUrl);
+
+    const param = akeyless.CreateSecret.constructFromObject({
+        token,
+        name,
+        value,
+        type: "generic",       // Text secret (can change to 'static' etc)
+        format: "text",
+        accessibility: "regular",
+    });
+
+    try {
+        const result = await api.createSecret(param);
+        core.info(`✅ Secret ${name} created successfully`);
+        return result;
+    } catch (error) {
+        core.setFailed(`❌ Failed to create secret: ${typeof error === 'object' ? JSON.stringify(error) : error}`);
+        throw error;
+    }
+}
+
+
 exports.handleExportSecrets = handleExportSecrets
+exports.createSecret = createSecret
+
+
 
 
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -234,3 +234,6 @@ function parseJson(jsonString) {
 }
 
 exports.handleExportSecrets = handleExportSecrets
+
+
+

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -234,7 +234,6 @@ function parseJson(jsonString) {
     }
 }
 
-
 async function handleCreateSecrets(args) {
     const {
         akeylessToken,
@@ -274,8 +273,6 @@ async function handleCreateSecrets(args) {
         }
     }
 }
-
-
 
 async function handleUpdateSecrets(args) {
     const {
@@ -318,10 +315,6 @@ async function handleUpdateSecrets(args) {
 }
 
 exports.handleUpdateSecrets = handleUpdateSecrets;
-
-
-
-
 exports.handleExportSecrets = handleExportSecrets
 exports.handleCreateSecrets = handleCreateSecrets;
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -234,36 +234,46 @@ function parseJson(jsonString) {
 }
 
 
-async function createSecret(token, name, value, apiUrl) {
+async function handleCreateSecrets(args) {
+    const {
+        akeylessToken,
+        secretsToCreate,
+        apiUrl,
+    } = args;
+
+    if (!secretsToCreate || secretsToCreate.length === 0) {
+        core.info('No secrets to create. Skipping secret creation.');
+        return;
+    }
+
     const api = akeylessApi.api(apiUrl);
 
-    core.info(`🚀 About to call createSecret`);
-    core.info(`Token Length: ${token.length}`);
-    core.info(`Name: ${name}`);
-    core.info(`Value: ${value}`);
+    for (const secret of secretsToCreate) {
+        const { name, value } = secret;
 
-    const param = akeyless.CreateSecret.constructFromObject({
-        token,
-        name,
-        value,
-        type: "generic",
-        format: "text",
-        accessibility: "regular",
-    });
+        if (!name || !value) {
+            core.warning(`Skipping secret creation due to missing name or value: ${JSON.stringify(secret)}`);
+            continue;
+        }
 
-    core.info(`CreateSecret Param: ${JSON.stringify(param)}`);
+        const param = akeyless.CreateSecret.constructFromObject({
+            token: akeylessToken,
+            name,
+            value,
+            type: "generic",
+            format: "text",
+            accessibility: "regular",
+        });
 
-    try {
-        const result = await api.createSecret(param);
-        core.info(`✅ CreateSecret API call succeeded`);
-        core.info(`API Response: ${JSON.stringify(result)}`);
-        return result;
-    } catch (error) {
-        core.error(`❌ API call to createSecret FAILED`);
-        core.error(`Error: ${typeof error === 'object' ? JSON.stringify(error) : error}`);
-        throw error;
+        try {
+            const result = await api.createSecret(param);
+            core.info(`✅ Secret ${name} created successfully`);
+        } catch (error) {
+            core.warning(`❌ Failed to create secret '${name}': ${typeof error === 'object' ? JSON.stringify(error) : error}`);
+        }
     }
 }
+
 
 
 

--- a/src/secrets.js
+++ b/src/secrets.js
@@ -268,9 +268,9 @@ async function handleCreateSecrets(args) {
 
         try {
             const result = await api.createSecret(param);
-            core.info(`✅ Secret ${name} created successfully`);
+            core.info(`Secret ${name} created successfully`);
         } catch (error) {
-            core.warning(`❌ Failed to create secret '${name}': ${typeof error === 'object' ? JSON.stringify(error) : error}`);
+            core.warning(`Failed to create secret '${name}': ${typeof error === 'object' ? JSON.stringify(error) : error}`);
         }
     }
 }
@@ -310,9 +310,9 @@ async function handleUpdateSecrets(args) {
 
         try {
             const result = await api.updateSecretVal(param);
-            core.info(`✅ Secret ${name} updated successfully`);
+            core.info(`Secret ${name} updated successfully`);
         } catch (error) {
-            core.warning(`❌ Failed to update secret '${name}': ${typeof error === 'object' ? JSON.stringify(error) : error}`);
+            core.warning(`Failed to update secret '${name}': ${typeof error === 'object' ? JSON.stringify(error) : error}`);
         }
     }
 }


### PR DESCRIPTION
Changes included:

- Added two new optional inputs: create-secret-name and create-secret-value (for secret creation). 
- Added two new optional inputs: update-secret-name and update-secret-value (for secret update).
- Implemented handleCreateSecrets() and handleUpdateSecrets() functions in secrets.js.
- Updated index.js to handle both secret creation and update flows before secret fetching.


Backward Compatibility:

- No breaking changes.
- Existing workflows that fetch secrets continue to work as before.

